### PR TITLE
Refactore relationship type

### DIFF
--- a/site/app/Card.php
+++ b/site/app/Card.php
@@ -13,7 +13,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Auth;
 

--- a/site/app/Card.php
+++ b/site/app/Card.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -83,33 +84,33 @@ class Card extends Model
     /**
      * Get the course of this card.
      */
-    public function course(): HasOne
+    public function course(): BelongsTo
     {
-        return $this->hasOne('App\Course', 'id', 'course_id');
+        return $this->belongsTo(Course::class);
     }
 
     /**
      * Get the folder of this card.
      */
-    public function folder(): HasOne
+    public function folder(): BelongsTo
     {
-        return $this->hasOne('App\Folder', 'id', 'folder_id');
+        return $this->belongsTo(Folder::class);
     }
 
     /**
-     * Get the file of this card.
+     * Get the file of this card (regular).
      */
-    public function file(): HasOne
+    public function file(): BelongsTo
     {
-        return $this->hasOne('App\File', 'id', 'file_id');
+        return $this->belongsTo(File::class);
     }
 
     /**
      * Get the state of this card.
      */
-    public function state(): HasOne
+    public function state(): BelongsTo
     {
-        return $this->hasOne('App\State', 'id', 'state_id');
+        return $this->belongsTo(State::class);
     }
 
     /**
@@ -125,7 +126,7 @@ class Card extends Model
      */
     public function attachments(): HasMany
     {
-        return $this->hasMany('App\File', 'card_id')
+        return $this->hasMany(File::class)
             ->withoutGlobalScope(HideAttachmentsScope::class)
             ->orderBy('created_at', 'desc');
     }

--- a/site/app/Course.php
+++ b/site/app/Course.php
@@ -48,27 +48,27 @@ class Course extends Model
     /**
      * Get the cards of this course.
      */
-    public function cards()
+    public function cards(): HasMany
     {
-        return $this->hasMany('App\Card', 'course_id')
+        return $this->hasMany(Card::class)
             ->orderBy('created_at', 'desc');
     }
 
     /**
      * Get the enrollments of this course.
      */
-    public function enrollments()
+    public function enrollments(): HasMany
     {
-        return $this->hasMany('App\Enrollment', 'course_id')
+        return $this->hasMany(Enrollment::class)
             ->orderBy('created_at', 'desc');
     }
 
     /**
      * Get the invitations of this course.
      */
-    public function invitations()
+    public function invitations(): HasMany
     {
-        return $this->hasMany('App\Invitation', 'course_id')
+        return $this->hasMany(Invitation::class)
             ->orderBy('created_at', 'desc');
     }
 
@@ -84,18 +84,18 @@ class Course extends Model
     /**
      * Get the files of this course.
      */
-    public function files()
+    public function files(): HasMany
     {
-        return $this->hasMany('App\File', 'course_id')
+        return $this->hasMany(File::class)
             ->orderBy('created_at', 'desc');
     }
 
     /**
      * Get the states of this course.
      */
-    public function states()
+    public function states(): HasMany
     {
-        return $this->hasMany('App\State', 'course_id')
+        return $this->hasMany(State::class)
             ->orderBy('created_at', 'desc');
     }
 

--- a/site/app/Enrollment.php
+++ b/site/app/Enrollment.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Enrollment extends Model
@@ -21,17 +22,17 @@ class Enrollment extends Model
     /**
      * Get the course of this enrollment.
      */
-    public function course()
+    public function course(): BelongsTo
     {
-        return $this->hasOne('App\Course', 'id', 'course_id');
+        return $this->belongsTo(Course::class);
     }
 
     /**
      * Get the user of this enrollment.
      */
-    public function user()
+    public function user(): BelongsTo
     {
-        return $this->hasOne('App\User', 'id', 'user_id');
+        return $this->belongsTo(User::class);
     }
 
     /**

--- a/site/app/File.php
+++ b/site/app/File.php
@@ -6,7 +6,6 @@ use App\Scopes\HideAttachmentsScope;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class File extends Model

--- a/site/app/File.php
+++ b/site/app/File.php
@@ -4,6 +4,7 @@ namespace App;
 
 use App\Scopes\HideAttachmentsScope;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -46,17 +47,17 @@ class File extends Model
     /**
      * Get the course of this file.
      */
-    public function course(): HasOne
+    public function course(): BelongsTo
     {
-        return $this->hasOne('App\Course', 'id', 'course_id');
+        return $this->belongsTo(Course::class);
     }
 
     /**
      * Get the card of this file (attachment).
      */
-    public function card(): HasOne
+    public function card(): BelongsTo
     {
-        return $this->hasOne('App\Card', 'id', 'card_id');
+        return $this->belongsTo(Card::class);
     }
 
     /**
@@ -64,7 +65,7 @@ class File extends Model
      */
     public function cards(): HasMany
     {
-        return $this->hasMany('App\Card', 'file_id')
+        return $this->hasMany(Card::class)
             ->orderBy('created_at', 'desc');
     }
 

--- a/site/app/Folder.php
+++ b/site/app/Folder.php
@@ -3,13 +3,16 @@
 namespace App;
 
 use App\Enums\FinderItemType;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 
 class Folder extends Model
 {
     use SoftDeletes;
+    use HasFactory;
 
     protected $fillable = [
         'title', 'position', 'course_id', 'parent_id',
@@ -22,9 +25,9 @@ class Folder extends Model
     /**
      * Get the course of this folder.
      */
-    public function course()
+    public function course() : BelongsTo
     {
-        return $this->hasOne('App\Course', 'id', 'course_id');
+        return $this->belongsTo(Course::class);
     }
 
     /**

--- a/site/app/Folder.php
+++ b/site/app/Folder.php
@@ -6,13 +6,14 @@ use App\Enums\FinderItemType;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 
 class Folder extends Model
 {
-    use SoftDeletes;
     use HasFactory;
+    use SoftDeletes;
 
     protected $fillable = [
         'title', 'position', 'course_id', 'parent_id',
@@ -25,7 +26,7 @@ class Folder extends Model
     /**
      * Get the course of this folder.
      */
-    public function course() : BelongsTo
+    public function course(): BelongsTo
     {
         return $this->belongsTo(Course::class);
     }
@@ -33,26 +34,26 @@ class Folder extends Model
     /**
      * Get the parent of this folder.
      */
-    public function parent()
+    public function parent(): BelongsTo
     {
-        return $this->hasOne('App\Folder', 'id', 'parent_id');
+        return $this->belongsTo(Folder::class, 'parent_id');
     }
 
     /**
      * Get the children of this folder.
      */
-    public function children()
+    public function children(): HasMany
     {
-        return $this->hasMany('App\Folder', 'parent_id')
+        return $this->hasMany(Folder::class, 'parent_id')
             ->orderBy('created_at', 'desc');
     }
 
     /**
      * Get the cards of this folder.
      */
-    public function cards()
+    public function cards(): HasMany
     {
-        return $this->hasMany('App\Card', 'folder_id')
+        return $this->hasMany(Card::class)
             ->orderBy('created_at', 'desc');
     }
 

--- a/site/app/Invitation.php
+++ b/site/app/Invitation.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Invitation extends Model
@@ -20,17 +21,17 @@ class Invitation extends Model
     /**
      * Get the user who created the invitation.
      */
-    public function creator()
+    public function creator(): BelongsTo
     {
-        return $this->hasOne('App\User', 'id', 'creator_id');
+        return $this->belongsTo(User::class, 'creator_id');
     }
 
     /**
      * Get the course linked to the invitation.
      */
-    public function course()
+    public function course(): BelongsTo
     {
-        return $this->hasOne('App\Course', 'id', 'course_id');
+        return $this->belongsTo(Course::class);
     }
 
     /**

--- a/site/app/State.php
+++ b/site/app/State.php
@@ -8,6 +8,8 @@ use App\Enums\StateType;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\EloquentSortable\Sortable;
 use Spatie\EloquentSortable\SortableTrait;
@@ -63,17 +65,17 @@ class State extends Model implements Sortable
     /**
      * Get the course of this card.
      */
-    public function course()
+    public function course(): BelongsTo
     {
-        return $this->hasOne('App\Course', 'id', 'course_id');
+        return $this->belongsTo(Course::class);
     }
 
     /**
      * Get the cards of this state.
      */
-    public function cards()
+    public function cards(): HasMany
     {
-        return $this->hasMany('App\Card', 'state_id')
+        return $this->hasMany(Card::class)
             ->orderBy('created_at', 'desc');
     }
 

--- a/site/app/User.php
+++ b/site/app/User.php
@@ -8,6 +8,7 @@ use DateTime;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
@@ -71,18 +72,18 @@ class User extends Authenticatable
     /**
      * Get the invitations created by the user.
      */
-    public function invitations()
+    public function invitations(): HasMany
     {
-        return $this->hasMany('App\Invitation', 'creator_id')
+        return $this->hasMany(Invitation::class, 'creator_id')
             ->orderBy('created_at', 'desc');
     }
 
     /**
      * Get the enrollments of this user.
      */
-    public function enrollments()
+    public function enrollments(): HasMany
     {
-        return $this->hasMany('App\Enrollment', 'user_id')
+        return $this->hasMany(Enrollment::class)
             ->orderBy('created_at', 'desc');
     }
 

--- a/site/tests/Feature/CardTest.php
+++ b/site/tests/Feature/CardTest.php
@@ -51,15 +51,20 @@ class CardTest extends TestCase
 
     public function testCardPositionCorrectlyInitialized()
     {
-        $course = Course::factory()->hasCards(3)->create();
+        $course = Course::factory()->create();
 
-        $this->assertEquals(0, $course->cards->first()->position);
-        $this->assertEquals(2, $course->cards->last()->position);
+        // We create sequentially entities for the observer to set the position
+        // correctly.
 
-        Folder::factory()->count(7)->for($course)->create();
+        for ($i = 0; $i < 3; $i++) {
+            $card = Card::factory()->for($course)->create();
+            $this->assertEquals($i, $card->position);
+        }
 
-        $this->assertEquals(3, $course->folders->first()->position);
-        $this->assertEquals(9, $course->folders->last()->position);
+        for (; $i < 7; $i++) {
+            $folder = Folder::factory()->for($course)->create();
+            $this->assertEquals($i, $folder->position);
+        }
     }
 
     public function testCloneCardInsideFolder()

--- a/site/tests/Feature/CardTest.php
+++ b/site/tests/Feature/CardTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Card;
 use App\Course;
+use App\Folder;
 use App\Services\Clone\CloneCardService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -50,10 +51,13 @@ class CardTest extends TestCase
 
     public function testCardPositionCorrectlyInitialized()
     {
-        $course = Course::factory()->hasCards(3)->hasFolders(7)->create();
+        $course = Course::factory()->hasCards(3)->create();
 
         $this->assertEquals(0, $course->cards->first()->position);
         $this->assertEquals(2, $course->cards->last()->position);
+
+        Folder::factory()->count(7)->for($course)->create();
+
         $this->assertEquals(3, $course->folders->first()->position);
         $this->assertEquals(9, $course->folders->last()->position);
     }


### PR DESCRIPTION
Using BelongsTo instead of HasOne for the opposite of HasMany or HasOne when the model is the one with the foreign key.